### PR TITLE
chore: add nightly CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  check-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up MoonBit (nightly)
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+
+      - name: Show MoonBit version
+        run: moon version --all
+
+      - name: Update dependencies
+        run: moon update
+
+      - name: Check
+        run: moon check
+
+      - name: Test
+        run: moon test


### PR DESCRIPTION
## Why

This repo currently ships no GitHub Actions workflows, so broken changes
on `main` aren't caught until someone runs `moon check` locally. Adds a
simple CI job that runs on every push and PR.

## What the workflow does

- Installs MoonBit from the `nightly` channel
  (`https://cli.moonbitlang.com/install/unix.sh | bash -s nightly`)
- `moon update`
- `moon check`
- `moon test`

No format check for now — wanted to keep this change low-friction; can be
added later.

Based on the existing `moonbit-community/loop_invariants` CI template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbit-community/unmarshal.mbt/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
