### PR TITLE
Fix MoonBit warnings for 2026-05-09 promotion

### DIFF
--- a/decoder.mbt
+++ b/decoder.mbt
@@ -427,7 +427,7 @@ fn Decoder::decode_string_with_length(
   let string_bytes = view[:len]
   let remaining = view[len:]
   self.update_view(remaining)
-  let marshal_value = MString(string_bytes.to_bytes())
+  let marshal_value = MString(string_bytes.to_owned())
   self.add_shared_object(marshal_value)
   marshal_value
 }
@@ -551,7 +551,7 @@ fn Decoder::decode_custom_block_with_length(
   guard view.length() >= data_length else {
     fail("Insufficient data for custom block payload of length \{data_length}")
   }
-  let data_bytes = view[:data_length].to_bytes()
+  let data_bytes = view[:data_length].to_owned()
   self.update_view(view[data_length:])
   let marshal_value = MCustom(identifier, data_bytes)
   self.add_shared_object(marshal_value)
@@ -584,7 +584,7 @@ fn Decoder::decode_custom_block_fixed(self : Self) -> MarshalValue raise {
   guard view.length() >= data_length else {
     fail("Insufficient data for custom block '\{identifier}' payload")
   }
-  let data_bytes = view[:data_length].to_bytes()
+  let data_bytes = view[:data_length].to_owned()
   self.update_view(view[data_length:])
   let marshal_value = MCustom(identifier, data_bytes)
   self.add_shared_object(marshal_value)
@@ -605,7 +605,7 @@ fn Decoder::read_null_terminated_string(self : Self) -> Bytes raise {
   }
 
   // Extract the string bytes (without null terminator)
-  let str_bytes = view[:len].to_bytes()
+  let str_bytes = view[:len].to_owned()
 
   // Update position past the string and null terminator
   self.update_view(view[len + 1:])

--- a/unmarshal_realworld_test.mbt
+++ b/unmarshal_realworld_test.mbt
@@ -31,7 +31,7 @@ test "decode real-world OCaml marshal data" {
   println("Found OCaml marshal magic at offset: \{marshal_offset}")
 
   // Extract the OCaml marshal data (from offset to end)
-  let marshal_data = unmarshal_blob[marshal_offset:].to_bytes()
+  let marshal_data = unmarshal_blob[marshal_offset:].to_owned()
 
   // Decode both header and value
   let decoder = Decoder::new(marshal_data)
@@ -78,7 +78,7 @@ test "decode real-world OCaml marshal data from unmarshal.core" {
   println("Found OCaml marshal magic at offset: \{marshal_offset}")
 
   // Extract the OCaml marshal data (from offset to end)
-  let marshal_data = unmarshal_core[marshal_offset:].to_bytes()
+  let marshal_data = unmarshal_core[marshal_offset:].to_owned()
 
   // Decode header only - avoid decoding full value due to very large circular structure
   let decoder = Decoder::new(marshal_data)


### PR DESCRIPTION
## Summary
- Fix MoonBit warnings reported by the community-cakes dashboard for the 2026-05-09 promotion run.
- Update deprecated APIs and debug assertions as needed.

## Validation
- `moon check --target all`
- `moon fmt`
- Tests were run where feasible during the promotion pass.
