### PR TITLE
Fix MoonBit nightly warnings

### DIFF
--- a/cmd/main/moon.pkg
+++ b/cmd/main/moon.pkg
@@ -1,3 +1,1 @@
-options(
-  "is-main": true,
-)
+pkgtype(kind: "executable")

--- a/cmd/main/pkg.generated.mbti
+++ b/cmd/main/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/unmarshal/cmd/main"
 // Type aliases
 
 // Traits
-

--- a/decoder/pkg.generated.mbti
+++ b/decoder/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub fn Decoder::new(Bytes) -> Self
 // Type aliases
 
 // Traits
-

--- a/dot/pkg.generated.mbti
+++ b/dot/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub fn DotBuilder::with_config(graph_name~ : String, rankdir~ : String) -> Self
 // Type aliases
 
 // Traits
-

--- a/encoder/pkg.generated.mbti
+++ b/encoder/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn marshal(@unmarshal.MarshalValue) -> Bytes raise
 // Type aliases
 
 // Traits
-

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -17,6 +17,18 @@ pub(all) struct MarshalHeader {
   size_32 : Int
   size_64 : Int
 } derive(Eq, ToJson, @debug.Debug)
+#deprecated
+pub fn MarshalHeader::equal(Self, Self) -> Bool
+#deprecated
+pub fn MarshalHeader::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn MarshalHeader::output(Self, &Logger) -> Unit
+#deprecated
+pub fn MarshalHeader::to_json(Self) -> Json
+#deprecated
+pub fn MarshalHeader::to_repr(Self) -> @debug.Repr
+#deprecated
+pub fn MarshalHeader::to_string(Self) -> String
 pub impl Show for MarshalHeader
 
 pub(all) enum MarshalValue {
@@ -27,9 +39,24 @@ pub(all) enum MarshalValue {
   MBlock(tag~ : Int, Array[MarshalValue])
   MCustom(String, Bytes)
 } derive(Eq, Hash, ToJson, @debug.Debug)
+#deprecated
+pub fn MarshalValue::equal(Self, Self) -> Bool
+#deprecated
+pub fn MarshalValue::hash(Self) -> Int
+#deprecated
+pub fn MarshalValue::hash_combine(Self, Hasher) -> Unit
+#deprecated
+pub fn MarshalValue::not_equal(Self, Self) -> Bool
+#deprecated
+pub fn MarshalValue::output(Self, &Logger) -> Unit
+#deprecated
+pub fn MarshalValue::to_json(Self) -> Json
+#deprecated
+pub fn MarshalValue::to_repr(Self) -> @debug.Repr
+#deprecated
+pub fn MarshalValue::to_string(Self) -> String
 pub impl Show for MarshalValue
 
 // Type aliases
 
 // Traits
-

--- a/types.mbt
+++ b/types.mbt
@@ -18,6 +18,18 @@ pub(all) struct MarshalHeader {
 } derive(Debug, Eq, ToJson)
 
 ///|
+#deprecated
+pub extend MarshalHeader with @debug.Debug::{to_repr}
+
+///|
+#deprecated
+pub extend MarshalHeader with Eq::{not_equal, equal}
+
+///|
+#deprecated
+pub extend MarshalHeader with ToJson::{to_json}
+
+///|
 /// Represents all possible OCaml values that can be unmarshaled
 /// 
 /// This enum covers the complete range of OCaml data types that can be
@@ -49,11 +61,39 @@ pub(all) enum MarshalValue {
 } derive(Debug, Eq, ToJson, Hash)
 
 ///|
+#deprecated
+pub extend MarshalValue with @debug.Debug::{to_repr}
+
+///|
+#deprecated
+pub extend MarshalValue with Eq::{not_equal, equal}
+
+///|
+#deprecated
+pub extend MarshalValue with ToJson::{to_json}
+
+///|
+#deprecated
+pub extend MarshalValue with Hash::{hash, hash_combine}
+
+///|
 pub impl Show for MarshalHeader with fn output(self, logger) {
-  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+  logger.write_string(
+    @debug.render(@debug.Debug::to_repr(self), max_depth=2147483647),
+  )
 }
 
 ///|
+#deprecated
+pub extend MarshalHeader with Show::{to_string, output}
+
+///|
 pub impl Show for MarshalValue with fn output(self, logger) {
-  logger.write_string(@debug.render(self.to_repr(), max_depth=2147483647))
+  logger.write_string(
+    @debug.render(@debug.Debug::to_repr(self), max_depth=2147483647),
+  )
 }
+
+///|
+#deprecated
+pub extend MarshalValue with Show::{to_string, output}

--- a/viz/pkg.generated.mbti
+++ b/viz/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn marshal_to_dot(@unmarshal.MarshalValue) -> String
 // Type aliases
 
 // Traits
-


### PR DESCRIPTION
## Summary

Fixes the MoonBit nightly warnings recorded by Community Cakes dashboard run #128.

- [0079] adds explicit public Debug, Eq, ToJson, Hash, and Show extensions for MarshalHeader and MarshalValue.
- Preserves the existing dot-method surface and behavior.
- Updates the tracked `moon info` interface snapshot; no public methods are removed.

## Verification

Moon `0.1.20260815` / moonc `v0.10.8+ab524e6b4-nightly`, with `MOON_IGNORE_PREBUILD=1 MOON_WORK=off`:

- Four-backend `moon check --deny-warn`
- Four-backend `moon test --deny-warn` — 105/105 on each backend
- `moon fmt`, `moon info`, and `git diff --check`

Baseline: Community Cakes dashboard run #128.